### PR TITLE
Add Multi-Lobby support

### DIFF
--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -1,15 +1,13 @@
-import { Player } from "./Player";
+import { TeamPlayer } from "./TeamPlayer";
 import { Team, Turn } from "./constants/Constants";
 
 import ws = require('ws')
 
-export class Agent extends Player {
-  team: Team;
+export abstract class Agent extends TeamPlayer {
   role: Turn;
   
   constructor(id: string, name: string, socket: ws, team: Team, role: Turn) {
-		super(id, name, socket);
-		this.team = team;
+		super(id, name, socket, team);
     this.role = role;
   }
 

--- a/src/Broadcaster.ts
+++ b/src/Broadcaster.ts
@@ -92,7 +92,7 @@ export function updateBoard(splayers: Agent[], board: [number, Card][]) {
 		sendToSloiterer(sloiterer, { action: "updateLoiterer", person: sloiterer, gid: gid });
 	}
 
-	export function updateLoitererToPlayer(sloiterer: Loiterer, splayer: Agent) {
+	export function updateLoitererToAgent(sloiterer: Loiterer, splayer: Agent) {
 		sendToSloiterer(sloiterer, { action: "updateLoitererToPlayer", player: splayer });
 	}
 

--- a/src/Broadcaster.ts
+++ b/src/Broadcaster.ts
@@ -9,58 +9,50 @@ import { Player } from './Player';
 
 export module Broadcaster {
 	function broadcastToPlayers(players: Player[], message: Object) {
-		for(let player of players) { sendToPlayer(player, message); }
+		players.forEach(player => sendToPlayer(player, message));
 	}
 
 	function sendToPlayer(player: Player, message: Object) {
 		player.socket.send(JSON.stringify(message));
 	}
 
-	function broadcastToSloiterers(sloiterers: Loiterer[], message: Object) {
-		for(let sloiterer of sloiterers) { sendToSloiterer(sloiterer, message); }
+	export function switchTurn(agents: Agent[], team: Team, turn: Turn) {
+		broadcastToPlayers(agents, { action: "switchTurn", team: team, turn: turn });
 	}
 
-	function sendToSloiterer(sloiterer: Loiterer, message: Object) {
-		sloiterer.socket.send(JSON.stringify(message));
+	export function switchActiveTeam(agents: Agent[], team: Team, turn: Turn) {
+		broadcastToPlayers(agents, { action: "switchActiveTeam", team: team, turn: turn });
 	}
 
-	export function switchTurn(players: Agent[], team: Team, turn: Turn) {
-		broadcastToPlayers(players, { action: "switchTurn", team: team, turn: turn });
+	export function postClue(agents: Agent[], clue: Clue, team: Team) {
+		broadcastToPlayers(agents, { action: "postClue", clue: clue, team: team });
 	}
 
-	export function switchActiveTeam(players: Agent[], team: Team, turn: Turn) {
-		broadcastToPlayers(players, { action: "switchActiveTeam", team: team, turn: turn });
+	export function generateCards(agents: Agent[], board: Board) {
+		broadcastToPlayers(agents, { action: "generateCards", board: Board });
 	}
 
-	export function postClue(players: Agent[], clue: Clue, team: Team) {
-		broadcastToPlayers(players, { action: "postClue", clue: clue, team: team });
-	}
-
-	export function generateCards(players: Agent[], board: Board) {
-		broadcastToPlayers(players, { action: "generateCards", board: Board });
-	}
-
-	export function updateTeams(sloiterers: Loiterer[], roster: [string[], string[]]) {
-		broadcastToSloiterers(sloiterers, { 
+	export function updateTeams(loiterers: Loiterer[], roster: [string[], string[]]) {
+		broadcastToPlayers(loiterers, { 
 			action: "updateTeams",
 			teams: { blue: roster[Team.blue], red: roster[Team.red] },
 		});
 	}
 
-	export function toggleStartButton(sloiterers: Loiterer[], canEnable: boolean) {
-		broadcastToSloiterers(sloiterers, { action: "toggleStartButton", enable: canEnable });
+	export function toggleStartButton(loiterers: Loiterer[], canEnable: boolean) {
+		broadcastToPlayers(loiterers, { action: "toggleStartButton", enable: canEnable });
 	}
 
-export function updateBoard(splayers: Agent[], board: [number, Card][]) {
-		broadcastToPlayers(splayers, { action: "updateBoard", board: board });
+	export function updateBoard(agents: Agent[], board: [number, Card][]) {
+		broadcastToPlayers(agents, { action: "updateBoard", board: board });
 	}
 
-	export function updateScore(splayers: Agent[], score: number[]) {
-		broadcastToPlayers(splayers, { action: "updateScore", score: score });
+	export function updateScore(agents: Agent[], score: number[]) {
+		broadcastToPlayers(agents, { action: "updateScore", score: score });
 	}
 
-	export function sendMessage(players: Agent[], chat: string, player) {
-		broadcastToPlayers(players, {
+	export function sendMessage(agents: Agent[], chat: string, player) {
+		broadcastToPlayers(agents, {
 			action: "sendMessage",
 			text: chat,
 			playerTeam: player.team,
@@ -68,32 +60,32 @@ export function updateBoard(splayers: Agent[], board: [number, Card][]) {
 		});
 	}
 
-	export function startGame(splayers: Agent[], startTeam: Team, startingRoster) {
-		broadcastToPlayers(splayers, { 
+	export function startGame(agents: Agent[], startTeam: Team, startingRoster) {
+		broadcastToPlayers(agents, { 
 			action: "gameStarted", startTeam: startTeam, roster: startingRoster
 		});
 	}
 
-	export function endGame(splayers: Agent[], team: Team) {
-		broadcastToPlayers(splayers, { action: "endGame", team: team });
+	export function endGame(agents: Agent[], team: Team) {
+		broadcastToPlayers(agents, { action: "endGame", team: team });
 	}
 
 	// PRIVATE
 
-	export function allowGuess(players: Agent[], bool: boolean) {
-		broadcastToPlayers(players, { action: "allowGuess", bool: bool });
+	export function allowGuess(agents: Agent[], bool: boolean) {
+		broadcastToPlayers(agents, { action: "allowGuess", bool: bool });
 	}
 
 	export function updateLoner(loner: Player) {
 		sendToPlayer(loner, { action: "updateLoner", person: loner });
 	}
 
-	export function updateLoiterer(sloiterer: Loiterer, gid: string) {
-		sendToSloiterer(sloiterer, { action: "updateLoiterer", person: sloiterer, gid: gid });
+	export function updateLoiterer(loiterer: Loiterer, gid: string) {
+		sendToPlayer(loiterer, { action: "updateLoiterer", person: loiterer, gid: gid });
 	}
 
-	export function updateLoitererToAgent(sloiterer: Loiterer, splayer: Agent) {
-		sendToSloiterer(sloiterer, { action: "updateLoitererToPlayer", player: splayer });
+	export function updateLoitererToAgent(loiterer: Loiterer, agent: Agent) {
+		sendToPlayer(loiterer, { action: "updateLoitererToPlayer", player: agent });
 	}
 
 	export function promptForClue(spymaster: Spymaster) {

--- a/src/Broadcaster.ts
+++ b/src/Broadcaster.ts
@@ -5,13 +5,14 @@ import { Board } from './Board'
 import { Agent } from './Agent'
 import { Loiterer } from './Loiterer'
 import { Spymaster } from './Spymaster'
+import { Player } from './Player';
 
 export module Broadcaster {
-	function broadcastToPlayers(players: Agent[], message: Object) {
+	function broadcastToPlayers(players: Player[], message: Object) {
 		for(let player of players) { sendToPlayer(player, message); }
 	}
 
-	function sendToPlayer(player: Agent, message: Object) {
+	function sendToPlayer(player: Player, message: Object) {
 		player.socket.send(JSON.stringify(message));
 	}
 
@@ -83,8 +84,12 @@ export function updateBoard(splayers: Agent[], board: [number, Card][]) {
 		broadcastToPlayers(players, { action: "allowGuess", bool: bool });
 	}
 
-	export function updateLoiterer(sloiterer: Loiterer) {
-		sendToSloiterer(sloiterer, { action: "updateLoiterer", person: sloiterer });
+	export function updateLoner(loner: Player) {
+		sendToPlayer(loner, { action: "updateLoner", person: loner });
+	}
+
+	export function updateLoiterer(sloiterer: Loiterer, gid: string) {
+		sendToSloiterer(sloiterer, { action: "updateLoiterer", person: sloiterer, gid: gid });
 	}
 
 	export function updateLoitererToPlayer(sloiterer: Loiterer, splayer: Agent) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -236,7 +236,7 @@ export class Game {
 				let sop: Operative = this.getAgentById(message.pid) as Operative;
 				if(re.isCardSelectable(this.board.cards, message.cardIndex)
 					&& re.isAgentTurn(this.currTeam, this.turn, sop)
-					&& !re.isPlayerSpy(sop)) {
+					&& !re.isAgentSpy(sop)) {
 					let previousSelection = this.board.cards.findIndex((card: Card) => {
 						return card.votes.indexOf(sop.name) !== -1;
 					});
@@ -254,7 +254,7 @@ export class Game {
 
 				let canGuess= re.canSubmitGuess(this.findOperatives(), this.currTeam);
 				if(canGuess
-					&& !re.isPlayerSpy(sop)
+					&& !re.isAgentSpy(sop)
 					&& re.isAgentTurn(this.currTeam, this.turn, sop)) {
 					this.guessAllowed();
 				}
@@ -284,7 +284,7 @@ export class Game {
 				console.log('Case sendMessage reached');
 
 				const agent = this.getAgentById(message.pid);
-				if(!re.isPlayerSpy(agent)) {
+				if(!re.isAgentSpy(agent)) {
 					Broadcaster.sendMessage(this.agents, message.text, agent)
 				}
 				break;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -79,33 +79,12 @@ export class Game {
 
 	// on socket close, remove person
 	// TODO: Weird typing between here and receiver
-	removePerson(socket: ws) {
-		var index = -1
-		let roster: [string[], string[]];
+	removeAgent(socket: ws) {
+		let index = this.players.findIndex(player => _.isEqual(player.socket, socket));
+		if (index > -1) { this.players.splice(index, 1) }
 
-		if (this.players.length == 0) {
-			for (var i = 0; i < this.loiterers.length; i++) {
-				if (_.isEqual(this.loiterers[i].socket, socket)) { index = i; }
-			}
-			if (index > -1) { this.loiterers.splice(index, 1); }
-
-			let teams = gu.getSloitererTeams(this.loiterers);
-			roster = gu.getSloitererRoster(teams);
-			Broadcaster.updateTeams(this.loiterers, roster);
-			
-			if (!re.canStartGame(teams)) {
-				Broadcaster.toggleStartButton(this.loiterers, false);
-			}
-		}
-		else {
-			for (var i = 0; i < this.players.length; i++) {
-				if (_.isEqual(this.players[i].socket, socket)) { index = i; }
-			}
-			if (index > -1) { this.players.splice(index, 1); }
-
-			roster = gu.getPlayerRoster(gu.getPlayerTeams(this.players));
-			Broadcaster.updateTeams(this.players, roster);
-		}
+		let roster = gu.getPlayerRoster(gu.getPlayerTeams(this.players));
+		Broadcaster.updateTeams(this.players, roster);
 	}
 
 	// turn loiterers into players

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -110,8 +110,8 @@ export class Game {
     return this.agents.filter(agent => agent.role === Turn.op) as Operative[];
 	}
 
-	getPlayerById(id: string): Agent {
-    // TODO: REALLLLLLLLY SHOULDNT CAST LIKE THIS
+	// TODO: REALLLLLLLLY SHOULDNT CAST LIKE THIS
+	getAgentById(id: string): Agent {
     return this.agents.find(agent => agent.id === id) as Agent;
 	}
 
@@ -218,7 +218,7 @@ export class Game {
 			case "sendClue":
 				console.log('Case sendClue reached');
 				if(re.isLegalClue(message.clue, this.board.cards)
-				&& re.isPlayerTurn(this.currTeam, this.turn, this.getPlayerById(message.pid))) {
+				&& re.isPlayerTurn(this.currTeam, this.turn, this.getAgentById(message.pid))) {
 					this.initializeClue(message.clue);
 				} else {
 					if(!re.isValidWord(message.clue.word)) {
@@ -233,7 +233,7 @@ export class Game {
 
 			case "toggleCard": {
 				console.log('Case toggleCard reached');
-				let sop: Operative = this.getPlayerById(message.pid) as Operative;
+				let sop: Operative = this.getAgentById(message.pid) as Operative;
 				if(re.isCardSelectable(this.board.cards, message.cardIndex)
 					&& re.isPlayerTurn(this.currTeam, this.turn, sop)
 					&& !re.isPlayerSpy(sop)) {
@@ -264,7 +264,7 @@ export class Game {
 
 			case "submitGuess":
 				console.log('Case submitGuess reached');
-				let sop: Operative = this.getPlayerById(message.pid) as Operative;
+				let sop: Operative = this.getAgentById(message.pid) as Operative;
 				let currSelection = this.board.cards.findIndex((card: Card) => {
 					return card.votes.indexOf(sop.name) !== -1;
 				});
@@ -283,7 +283,7 @@ export class Game {
 			case "sendMessage":
 				console.log('Case sendMessage reached');
 
-				const agent = this.getPlayerById(message.pid);
+				const agent = this.getAgentById(message.pid);
 				if(!re.isPlayerSpy(agent)) {
 					Broadcaster.sendMessage(this.agents, message.text, agent)
 				}
@@ -292,7 +292,7 @@ export class Game {
 			case "endTurn":
 				console.log('Case endTurn reached');
 
-				let sp: Agent = this.getPlayerById(message.pid) as Agent;
+				let sp: Agent = this.getAgentById(message.pid) as Agent;
 				if(re.isPlayerTurn(this.currTeam, this.turn, sp)) {
 					this.switchActiveTeam();
 				}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -68,7 +68,7 @@ export class Game {
 			let agent = haveTeamSpy
 				? Operative.loitererToOperative(loiterer)
 				: Spymaster.loitererToSpymaster(loiterer);
-			Broadcaster.updateLoitererToPlayer(loiterer, agent);
+			Broadcaster.updateLoitererToAgent(loiterer, agent);
 
 			return agent;
 		});

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -47,46 +47,6 @@ export class Game {
 		Broadcaster.updateBoard(spymasters, this.boardToColorsAndCards(true));
 	}
 
-	// adds new loiterer to play class
-	// TODO: Weird typing issue between here and Receiver
-  // registerLoiterer(name: string, socket) {
-	// 	let beforeTeams: SLoitererTeams = gu.getSloitererTeams(this.loiterers);
-	// 	let team: Team = beforeTeams.blue.length <= beforeTeams.red.length ? Team.blue : Team.red;
-	// 	let id = Date.now().toString(36);
-
-  //   let newLoiterer = new Loiterer(id, name, socket, team);
-  //   this.loiterers.push(newLoiterer);
-  //   let afterTeams = gu.getSloitererTeams(this.loiterers);
-
-	// 	// Broadcaster.updateLoiterer(newLoiterer);
-	// 	Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(afterTeams));
-
-	// 	if (re.canStartGame(afterTeams)) {
-	// 		Broadcaster.toggleStartButton(this.loiterers, true);
-	// 	}
-  // }
-
-	// switches loiterer team
-	switchLoitererTeam(id: string) {
-		for (var i = 0; i < this.loiterers.length; i++) {
-			if (this.loiterers[i].id === id) {
-				var team = this.loiterers[i].team
-				team = gu.getOtherTeam(team);
-				this.loiterers[i].team = team;
-			}
-    }
-
-		let sloitererTeams = gu.getSloitererTeams(this.loiterers);
-
-		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(sloitererTeams));
-		if (re.canStartGame(sloitererTeams)) {
-			Broadcaster.toggleStartButton(this.loiterers, true);
-		}
-    else {
-      Broadcaster.toggleStartButton(this.loiterers, false);
-    }
-	}
-
 	// on socket close, remove person
 	// TODO: Weird typing between here and receiver
 	removePerson(socket: ws) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1,5 +1,6 @@
 import { Clue } from './Clue';
 import { Card } from './Card'
+import { Teams } from './Teams';
 import { Lobby } from './Lobby';
 import { Board } from './Board';
 import { Agent } from './Agent';
@@ -9,7 +10,6 @@ import { Loiterer } from './Loiterer';
 import { Broadcaster } from './Broadcaster';
 import { GameUtility as gu } from './GameUtility'
 import { RuleEnforcer as re } from './RuleEnforcer';
-import { SPlayerTeams, SLoitererTeams } from './Teams'
 import { Color, Team, Turn } from './constants/Constants';
 
 import ws = require('ws');
@@ -79,7 +79,7 @@ export class Game {
 		let index = this.agents.findIndex(agent => _.isEqual(agent.socket, socket));
 		if (index > -1) { this.agents.splice(index, 1) }
 
-		let roster = gu.getPlayerRoster(gu.getPlayerTeams(this.agents));
+		let roster = gu.getRoster(gu.getTeams(this.agents));
 		Broadcaster.updateTeams(this.agents, roster);
 	}
 
@@ -156,7 +156,7 @@ export class Game {
   }
 
 	guessAllowed(): void {
-		let teams = gu.getPlayerTeams(this.agents);
+		let teams = gu.getTeams(this.agents);
 		Broadcaster.allowGuess(this.currTeam === Team.red ? teams.red : teams.blue, true);
 	}
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -215,6 +215,10 @@ export class Game {
 		Broadcaster.endGame(this.players, team);
 	}
 
+	empty(): boolean {
+		return this.players.length === 0;
+	}
+
 	handleMessage(message: any, socket: ws) {
 		switch(message.action) {
 			case "sendClue":

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -49,22 +49,22 @@ export class Game {
 
 	// adds new loiterer to play class
 	// TODO: Weird typing issue between here and Receiver
-  registerLoiterer(name: string, socket) {
-		let beforeTeams: SLoitererTeams = gu.getSloitererTeams(this.loiterers);
-		let team: Team = beforeTeams.blue.length <= beforeTeams.red.length ? Team.blue : Team.red;
-		let id = Date.now().toString(36);
+  // registerLoiterer(name: string, socket) {
+	// 	let beforeTeams: SLoitererTeams = gu.getSloitererTeams(this.loiterers);
+	// 	let team: Team = beforeTeams.blue.length <= beforeTeams.red.length ? Team.blue : Team.red;
+	// 	let id = Date.now().toString(36);
 
-    let newLoiterer = new Loiterer(id, name, socket, team);
-    this.loiterers.push(newLoiterer);
-    let afterTeams = gu.getSloitererTeams(this.loiterers);
+  //   let newLoiterer = new Loiterer(id, name, socket, team);
+  //   this.loiterers.push(newLoiterer);
+  //   let afterTeams = gu.getSloitererTeams(this.loiterers);
 
-		Broadcaster.updateLoiterer(newLoiterer);
-		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(afterTeams));
+	// 	// Broadcaster.updateLoiterer(newLoiterer);
+	// 	Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(afterTeams));
 
-		if (re.canStartGame(afterTeams)) {
-			Broadcaster.toggleStartButton(this.loiterers, true);
-		}
-  }
+	// 	if (re.canStartGame(afterTeams)) {
+	// 		Broadcaster.toggleStartButton(this.loiterers, true);
+	// 	}
+  // }
 
 	// switches loiterer team
 	switchLoitererTeam(id: string) {
@@ -275,7 +275,7 @@ export class Game {
 			case "sendClue":
 				console.log('Case sendClue reached');
 				if(re.isLegalClue(message.clue, this.board.cards)
-				&& re.isPlayerTurn(this.currTeam, this.turn, this.getPlayerById(message.id))) {
+				&& re.isPlayerTurn(this.currTeam, this.turn, this.getPlayerById(message.pid))) {
 					this.initializeClue(message.clue);
 				} else {
 					if(!re.isValidWord(message.clue.word)) {
@@ -290,7 +290,7 @@ export class Game {
 
 			case "toggleCard": {
 				console.log('Case toggleCard reached');
-				let sop: Operative = this.getPlayerById(message.id) as Operative;
+				let sop: Operative = this.getPlayerById(message.pid) as Operative;
 				if(re.isCardSelectable(this.board.cards, message.cardIndex)
 					&& re.isPlayerTurn(this.currTeam, this.turn, sop)
 					&& !re.isPlayerSpy(sop)) {
@@ -321,7 +321,7 @@ export class Game {
 
 			case "submitGuess":
 				console.log('Case submitGuess reached');
-				let sop: Operative = this.getPlayerById(message.id) as Operative;
+				let sop: Operative = this.getPlayerById(message.pid) as Operative;
 				let currSelection = this.board.cards.findIndex((card: Card) => {
 					return card.votes.indexOf(sop.name) !== -1;
 				});
@@ -340,7 +340,7 @@ export class Game {
 			case "sendMessage":
 				console.log('Case sendMessage reached');
 
-				const player = this.getPlayerById(message.id);
+				const player = this.getPlayerById(message.pid);
 				if(!re.isPlayerSpy(player)) {
 					Broadcaster.sendMessage(this.players, message.text, player)
 				}
@@ -349,7 +349,7 @@ export class Game {
 			case "endTurn":
 				console.log('Case endTurn reached');
 
-				let sp: Agent = this.getPlayerById(message.id) as Agent;
+				let sp: Agent = this.getPlayerById(message.pid) as Agent;
 				if(re.isPlayerTurn(this.currTeam, this.turn, sp)) {
 					this.switchActiveTeam();
 				}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -218,7 +218,7 @@ export class Game {
 			case "sendClue":
 				console.log('Case sendClue reached');
 				if(re.isLegalClue(message.clue, this.board.cards)
-				&& re.isPlayerTurn(this.currTeam, this.turn, this.getAgentById(message.pid))) {
+				&& re.isAgentTurn(this.currTeam, this.turn, this.getAgentById(message.pid))) {
 					this.initializeClue(message.clue);
 				} else {
 					if(!re.isValidWord(message.clue.word)) {
@@ -235,7 +235,7 @@ export class Game {
 				console.log('Case toggleCard reached');
 				let sop: Operative = this.getAgentById(message.pid) as Operative;
 				if(re.isCardSelectable(this.board.cards, message.cardIndex)
-					&& re.isPlayerTurn(this.currTeam, this.turn, sop)
+					&& re.isAgentTurn(this.currTeam, this.turn, sop)
 					&& !re.isPlayerSpy(sop)) {
 					let previousSelection = this.board.cards.findIndex((card: Card) => {
 						return card.votes.indexOf(sop.name) !== -1;
@@ -255,7 +255,7 @@ export class Game {
 				let canGuess= re.canSubmitGuess(this.findOperatives(), this.currTeam);
 				if(canGuess
 					&& !re.isPlayerSpy(sop)
-					&& re.isPlayerTurn(this.currTeam, this.turn, sop)) {
+					&& re.isAgentTurn(this.currTeam, this.turn, sop)) {
 					this.guessAllowed();
 				}
 
@@ -293,7 +293,7 @@ export class Game {
 				console.log('Case endTurn reached');
 
 				let sp: Agent = this.getAgentById(message.pid) as Agent;
-				if(re.isPlayerTurn(this.currTeam, this.turn, sp)) {
+				if(re.isAgentTurn(this.currTeam, this.turn, sp)) {
 					this.switchActiveTeam();
 				}
 

--- a/src/GameUtility.ts
+++ b/src/GameUtility.ts
@@ -1,32 +1,19 @@
-import { Agent } from './Agent'
-import { Loiterer } from './Loiterer'
+import { Teams } from './Teams'
 import { Operative } from './Operative';
+import { TeamPlayer } from './TeamPlayer';
 import { Team } from './constants/Constants'
-import { SPlayerTeams, SLoitererTeams } from './Teams'
 
-export module GameUtility {
-	export function getSloitererTeams(loiterers: Loiterer[]): SLoitererTeams {
-		return new SLoitererTeams(
-			loiterers.filter(loiterer => loiterer.team === Team.red),
-			loiterers.filter(loiterer => loiterer.team === Team.blue)
+export module GameUtility {	
+	export function getTeams<T extends TeamPlayer>(teamPlayers: T[]): Teams<T> {
+		return new Teams(
+			teamPlayers.filter(teamPlayer => teamPlayer.team === Team.red),
+			teamPlayers.filter(teamPlayer => teamPlayer.team === Team.blue)
 		);
 	}
-	
-	export function getPlayerTeams(players: Agent[]): SPlayerTeams {
-		return new SPlayerTeams(
-			players.filter(player => player.team === Team.red),
-			players.filter(player => player.team === Team.blue)
-		);
-	}
-	
-	export function getSloitererRoster(loiterers: SLoitererTeams): [string[], string[]] {
-		return [loiterers.blue.map(loiterer => loiterer.name), 
-						loiterers.red.map(loiterer => loiterer.name)];
-	}
-	
-	export function getPlayerRoster(players: SPlayerTeams): [string[], string[]] {
-			return [players.blue.map(player => player.name),
-							players.red.map(player => player.name)];
+
+	export function getRoster(teamPlayers: Teams<TeamPlayer>): [string[], string[]] {
+		return [teamPlayers.blue.map(teamPlayer => teamPlayer.name), 
+						teamPlayers.red.map(teamPlayer => teamPlayer.name)];
 	}
 	
 	export function getOtherTeam(team: Team) {

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -22,15 +22,15 @@ export class Lobby {
 	}
 
 	addPlayer(player: Player) {
-		let teams = gu.getSloitererTeams(this.loiterers);
+		let teams = gu.getTeams(this.loiterers);
 		let team: Team = teams.blue.length <= teams.red.length ? Team.blue : Team.red;
 
 		let loiterer = Loiterer.loitererFromPlayer(player, team);
 		this.loiterers.push(loiterer);
 
 		Broadcaster.updateLoiterer(loiterer, this.id);
-		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(gu.getSloitererTeams(this.loiterers)));
-		if (re.canStartGame(gu.getSloitererTeams(this.loiterers)))
+		Broadcaster.updateTeams(this.loiterers, gu.getRoster(gu.getTeams(this.loiterers)));
+		if (re.canStartGame(gu.getTeams(this.loiterers)))
 			Broadcaster.toggleStartButton(this.loiterers, true);
 	}
 
@@ -38,8 +38,8 @@ export class Lobby {
 		let index = this.loiterers.findIndex(loiterer => _.isEqual(loiterer.socket, socket));
 		if (index > -1) { this.loiterers.splice(index, 1) }
 
-		let teams = gu.getSloitererTeams(this.loiterers);
-		let roster = gu.getSloitererRoster(teams);
+		let teams = gu.getTeams(this.loiterers);
+		let roster = gu.getRoster(teams);
 		Broadcaster.updateTeams(this.loiterers, roster);
 		
 		if (!re.canStartGame(teams)) {
@@ -60,8 +60,8 @@ export class Lobby {
 			throw new Error('Loiterer does not exist when trying to switch teams');
 		}
 
-		let sloitererTeams = gu.getSloitererTeams(this.loiterers);
-		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(sloitererTeams));
+		let sloitererTeams = gu.getTeams(this.loiterers);
+		Broadcaster.updateTeams(this.loiterers, gu.getRoster(sloitererTeams));
 		Broadcaster.toggleStartButton(this.loiterers, re.canStartGame(sloitererTeams));
 	}
 }

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,0 +1,36 @@
+import { Loiterer } from './Loiterer'
+import { Broadcaster } from './Broadcaster'
+import { GameUtility as gu } from './GameUtility'
+import { RuleEnforcer as re } from './RuleEnforcer'
+
+import ws = require('ws')
+import * as _ from 'lodash'
+
+export class Lobby {
+	private loiterers: Loiterer[];
+
+	constructor(first: Loiterer) {
+		this.loiterers = [ first ];
+	}
+
+	addLoiterer(loiterer: Loiterer) {
+		this.loiterers.push(loiterer);
+	}
+
+	removeLoiterer(socket: ws) {
+		let index = this.loiterers.findIndex(loiterer => _.isEqual(loiterer.socket, socket));
+		if (index > -1) { this.loiterers.splice(index, 1) }
+
+		let teams = gu.getSloitererTeams(this.loiterers);
+		let roster = gu.getSloitererRoster(teams);
+		Broadcaster.updateTeams(this.loiterers, roster);
+		
+		if (!re.canStartGame(teams)) {
+			Broadcaster.toggleStartButton(this.loiterers, false);
+		}
+	}
+
+	getLoiterers(): Loiterer[] {
+		return this.loiterers;
+	}
+}

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,5 +1,7 @@
+import { Player } from './Player'
 import { Loiterer } from './Loiterer'
 import { Broadcaster } from './Broadcaster'
+import { Team } from './constants/Constants'
 import { GameUtility as gu } from './GameUtility'
 import { RuleEnforcer as re } from './RuleEnforcer'
 
@@ -15,8 +17,14 @@ export class Lobby {
 		this.loiterers = [];
 	}
 
-	addLoiterer(loiterer: Loiterer) {
+	addPlayer(player: Player) {
+		let teams = gu.getSloitererTeams(this.loiterers);
+		let team: Team = teams.blue.length <= teams.red.length ? Team.blue : Team.red;
+
+		let loiterer = Loiterer.loitererFromPlayer(player, team);
 		this.loiterers.push(loiterer);
+
+		Broadcaster.updateLoiterer(loiterer, this.id);
 		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(gu.getSloitererTeams(this.loiterers)));
 	}
 

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -8,6 +8,12 @@ import { RuleEnforcer as re } from './RuleEnforcer'
 import ws = require('ws')
 import * as _ from 'lodash'
 
+/**
+ * Manages a single lobby before a game has been started.
+ * 
+ * Provides methods for adding and removing players along with switching players
+ * from team to team.
+ */
 export class Lobby {
 	readonly id: string;
 	private loiterers: Loiterer[];

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -7,10 +7,12 @@ import ws = require('ws')
 import * as _ from 'lodash'
 
 export class Lobby {
+	readonly id: string;
 	private loiterers: Loiterer[];
 
-	constructor(first: Loiterer) {
-		this.loiterers = [ first ];
+	constructor(gid: string) {
+		this.id = gid;
+		this.loiterers = [];
 	}
 
 	addLoiterer(loiterer: Loiterer) {

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -17,6 +17,7 @@ export class Lobby {
 
 	addLoiterer(loiterer: Loiterer) {
 		this.loiterers.push(loiterer);
+		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(gu.getSloitererTeams(this.loiterers)));
 	}
 
 	removeLoiterer(socket: ws) {
@@ -34,5 +35,19 @@ export class Lobby {
 
 	getLoiterers(): Loiterer[] {
 		return this.loiterers;
+	}
+
+	switchLoitererTeam(pid: string) {
+		let loiterer = this.loiterers.find(loiterer => loiterer.id === pid);
+		if(loiterer) {
+			loiterer.team = gu.getOtherTeam(loiterer.team);
+		} else {
+			// handle without crashing in production
+			throw new Error('Loiterer does not exist when trying to switch teams');
+		}
+
+		let sloitererTeams = gu.getSloitererTeams(this.loiterers);
+		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(sloitererTeams));
+		Broadcaster.toggleStartButton(this.loiterers, re.canStartGame(sloitererTeams));
 	}
 }

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -17,6 +17,10 @@ export class Lobby {
 		this.loiterers = [];
 	}
 
+	empty(): boolean {
+		return this.loiterers.length === 0;
+	}
+
 	addPlayer(player: Player) {
 		let teams = gu.getSloitererTeams(this.loiterers);
 		let team: Team = teams.blue.length <= teams.red.length ? Team.blue : Team.red;

--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -26,6 +26,8 @@ export class Lobby {
 
 		Broadcaster.updateLoiterer(loiterer, this.id);
 		Broadcaster.updateTeams(this.loiterers, gu.getSloitererRoster(gu.getSloitererTeams(this.loiterers)));
+		if (re.canStartGame(gu.getSloitererTeams(this.loiterers)))
+			Broadcaster.toggleStartButton(this.loiterers, true);
 	}
 
 	removeLoiterer(socket: ws) {

--- a/src/Loiterer.ts
+++ b/src/Loiterer.ts
@@ -1,19 +1,11 @@
 import { Player } from './Player'
+import { TeamPlayer } from './TeamPlayer';
 import { Team } from "./constants/Constants";
 
 import ws = require('ws')
 
-export class Loiterer extends Player {
-  team: Team;
-
-  constructor(id: string, name: string, socket: ws, team: Team) {
-    super(id, name, socket);
-    this.team = team;
-  }
-
+export class Loiterer extends TeamPlayer {
   static loitererFromPlayer(player: Player, team: Team): Loiterer {
     return new Loiterer(player.id, player.name, player.socket, team);
   }
-
-  toJSON() { return { id: this.id, name: this.name, team: this.team }; }
 }

--- a/src/Loiterer.ts
+++ b/src/Loiterer.ts
@@ -11,7 +11,7 @@ export class Loiterer extends Player {
     this.team = team;
   }
 
-  static playerToLoiterer(player: Player, team: Team): Loiterer {
+  static loitererFromPlayer(player: Player, team: Team): Loiterer {
     return new Loiterer(player.id, player.name, player.socket, team);
   }
 

--- a/src/Loiterer.ts
+++ b/src/Loiterer.ts
@@ -11,5 +11,9 @@ export class Loiterer extends Player {
     this.team = team;
   }
 
+  static playerToLoiterer(player: Player, team: Team): Loiterer {
+    return new Loiterer(player.id, player.name, player.socket, team);
+  }
+
   toJSON() { return { id: this.id, name: this.name, team: this.team }; }
 }

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -6,7 +6,7 @@ import { Loiterer } from './Loiterer';
 import { Operative } from './Operative';
 import { PlayerState } from './PlayerState';
 import { Broadcaster } from './Broadcaster';
-import { Team } from './constants/Constants';
+import { Team, PlayerLocation } from './constants/Constants';
 import { GameUtility as gu } from './GameUtility';
 import { RuleEnforcer as re } from './RuleEnforcer';
 
@@ -32,9 +32,26 @@ export class Manager {
 			return;
 		}
 
+		// player exists somewhere
+		let state = this.playerStates.get(socket) as PlayerState;
+
+		switch(state.getLoc()) {
+			case PlayerLocation.loner:
+				this.removeLoner(socket, state.getPid())
+				console.log(`Removed player from loners with id: ${state.getPid()}`)
+				break;
+			default:
+				console.log('Sorry, unknown player location.')
+		}
+
 		console.log('Didn\'t close connection, FIX THIS');
 		// TODO: need to handle this somehow, map of sockets to gid?
 		// this.games.get().removePerson(socket);
+	}
+
+	removeLoner(socket: ws, pid: string): void {
+		this.loners.delete(pid);
+		this.playerStates.delete(socket);
 	}
 
 	handleMessage(message: any, socket: ws) {
@@ -100,6 +117,7 @@ export class Manager {
 		let loner = new Player(id, name, socket);
 		this.loners.set(id, loner);
 		
+		this.playerStates.set(socket, new PlayerState(id));
 		Broadcaster.updateLoner(loner);
 	}
 	

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -119,6 +119,8 @@ export class Manager {
 					let gid = message.gid.toLocaleLowerCase();
 					if(this.lobbies.has(gid))
 						this.placePlayerInLobby(message.pid, gid, socket);
+					else
+						socket.send(JSON.stringify({ action: "invalidLobby" }));
 					break;
 
 				case "switchTeam":

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -12,22 +12,21 @@ import ws = require('ws');
 import { Team } from './constants/Constants';
 
 export class Manager {
-	game: Game;
 	loners: Map<string, Player>;
 	lobbies: Map<string, Lobby>;
 	games: Map<string, Game>;
 
 	// make instance of Game class
 	constructor() {
-		this.game = new Game();
 		this.loners = new Map();
 		this.lobbies = new Map();
 		this.games = new Map();
 	}
 
 	handleClose(socket: ws) {
-		console.log('Closed connection');
-		this.game.removePerson(socket);
+		console.log('Didn\'t close connection, FIX THIS');
+		// TODO: need to handle this somehow, map of sockets to gid?
+		// this.games.get().removePerson(socket);
 	}
 
 	handleMessage(message: any, socket: ws) {
@@ -77,7 +76,8 @@ export class Manager {
 				case "toggleCard":
 				case "submitGuess":
 				case "sendMessage":
-					this.game.handleMessage(message, socket);
+					if(this.games.has(message.gid))
+						(this.games.get(message.gid) as Game).handleMessage(message, socket);
 					break;
 
 				default:

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -116,7 +116,7 @@ export class Manager {
 				case "startGame":
 					console.log('Case startGame reached');
 					if(this.lobbies.has(message.gid)
-					&& re.canStartGame(gu.getSloitererTeams((this.lobbies.get(message.gid) as Lobby).getLoiterers()))) {
+					&& re.canStartGame(gu.getTeams((this.lobbies.get(message.gid) as Lobby).getLoiterers()))) {
 						this.placePlayersInGame(message.gid);
 					}
 					break;

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -35,7 +35,7 @@ export class Manager {
 
 		if(message.hasOwnProperty('action')) {
 			let action: string = message.action;
-
+			
 			switch(action) {
 				case "setName":
 					console.log('Case setName reached');
@@ -56,8 +56,8 @@ export class Manager {
 					break;
 
 				case "switchTeam":
-					this.game.switchLoitererTeam(message.pid);
-					console.log('Case switchTeam reached');
+					if(this.lobbies.has(message.gid))
+						(this.lobbies.get(message.gid) as Lobby).switchLoitererTeam(message.pid);
 					break;
 
 				case "startGame":

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -4,26 +4,34 @@ import { Lobby } from './Lobby';
 import { Player } from './Player';
 import { Loiterer } from './Loiterer';
 import { Operative } from './Operative';
+import { PlayerState } from './PlayerState';
 import { Broadcaster } from './Broadcaster';
+import { Team } from './constants/Constants';
 import { GameUtility as gu } from './GameUtility';
 import { RuleEnforcer as re } from './RuleEnforcer';
 
 import ws = require('ws');
-import { Team } from './constants/Constants';
 
 export class Manager {
+	playerStates: Map<ws, PlayerState>;
 	loners: Map<string, Player>;
 	lobbies: Map<string, Lobby>;
 	games: Map<string, Game>;
 
 	// make instance of Game class
 	constructor() {
+		this.playerStates = new Map();
 		this.loners = new Map();
 		this.lobbies = new Map();
 		this.games = new Map();
 	}
 
 	handleClose(socket: ws) {
+		if(!this.playerStates.has(socket)) {
+			console.log('User hadn\'t set name, no player to remove');
+			return;
+		}
+
 		console.log('Didn\'t close connection, FIX THIS');
 		// TODO: need to handle this somehow, map of sockets to gid?
 		// this.games.get().removePerson(socket);

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -103,9 +103,7 @@ export class Manager {
 
 		let loner: Player = this.loners.get(pid) as Player;
 		this.loners.delete(pid);
-		let loiterer = Loiterer.playerToLoiterer(loner, Team.red);
-		(this.lobbies.get(gid) as Lobby).addLoiterer(loiterer)
-		Broadcaster.updateLoiterer(loiterer, gid);
+		(this.lobbies.get(gid) as Lobby).addPlayer(loner)
 		return true;
 	}
 }

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -48,14 +48,26 @@ export class Manager {
 				break;
 			case PlayerLocation.lobby:
 				if(this.lobbies.has(state.getGid())) {
-					(this.lobbies.get(state.getGid()) as Lobby).removeLoiterer(socket);
+					let lobby = (this.lobbies.get(state.getGid()) as Lobby);
+					lobby.removeLoiterer(socket);
 					console.log(`Removed player from lobby ${state.getGid()} with id: ${state.getPid()}`)
+
+					if(lobby.empty()) {
+						this.lobbies.delete(state.getGid());
+						console.log(`Deleted lobby ${state.getGid()}`);
+					}
 				}
 				break;
 			case PlayerLocation.game:
 				if(this.games.has(state.getGid())) {
-					(this.games.get(state.getGid()) as Game).removeAgent(socket);
-					console.log(`Removed player from game ${state.getGid()} with id: ${state.getPid()}`)
+					let game = (this.games.get(state.getGid()) as Game);
+					game.removeAgent(socket);
+					console.log(`Removed player from game ${state.getGid()} with id: ${state.getPid()}`);
+
+					if(game.empty()) {
+						this.games.delete(state.getGid());
+						console.log(`Deleted game ${state.getGid()}`);
+					}
 				}
 				break;
 			default:

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -62,9 +62,12 @@ export class Manager {
 
 				case "startGame":
 					console.log('Case startGame reached');
-					if(re.canStartGame(gu.getSloitererTeams(this.game.loiterers))) {
-						this.game.startGame();
-					};
+					if(this.lobbies.has(message.gid)
+					&& re.canStartGame(gu.getSloitererTeams((this.lobbies.get(message.gid) as Lobby).getLoiterers()))) {
+						let lobby: Lobby = this.lobbies.get(message.gid) as Lobby;
+						this.lobbies.delete(message.gid);
+						this.games.set(message.gid, Game.gameFromLobby(lobby));
+					}
 					break;
 
 				// game message

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -1,0 +1,138 @@
+import ws = require('ws')
+
+import { Card } from './Card'
+import { Game } from './Game'
+import { Player } from './Player'
+import { Operative } from './Operative'
+import { Broadcaster } from './Broadcaster';
+import { RuleEnforcer as re } from './RuleEnforcer';
+import { GameUtility as gu } from './GameUtility'
+
+export class Manager {
+	game: Game;
+
+	// make game instance of Game class
+	constructor() {
+		this.game = new Game();
+	}
+
+	handleClose(socket: ws) {
+		console.log('Closed connection');
+		this.game.removePerson(socket);
+	}
+
+	handleMessage(message: any, socket: ws) {
+		console.log(message)
+
+		if(message.hasOwnProperty('action')) {
+			let action: string = message.action;
+
+			switch(action) {
+				case "setName":
+					console.log('Case setName reached');
+					if (re.isValidName(message.name)) {
+						this.game.registerLoiterer(message.name, socket);
+					}
+					break;
+
+				case "switchTeam":
+					this.game.switchLoitererTeam(message.id);
+					console.log('Case switchTeam reached');
+					break;
+
+				case "startGame":
+					console.log('Case startGame reached');
+					if(re.canStartGame(gu.getSloitererTeams(this.game.loiterers))) {
+						this.game.startGame();
+					};
+					break;
+
+				case "sendClue":
+					console.log('Case sendClue reached');
+					if(re.isLegalClue(message.clue, this.game.board.cards)
+					&& re.isPlayerTurn(this.game.currTeam, this.game.turn, this.game.getPlayerById(message.id))) {
+						this.game.initializeClue(message.clue);
+					} else {
+						if(!re.isValidWord(message.clue.word)) {
+							socket.send(JSON.stringify({ action: "invalidClueWord", reason: "notWord"}));
+						} else if(re.isWordOnBoard(message.clue.word, this.game.board.cards)) {
+							socket.send(JSON.stringify({ action: "invalidClueWord", reason: "wordOnBoard"}));							
+						} else if(!re.isValidNumGuesses(message.clue.num)) {
+							socket.send(JSON.stringify({ action: "invalidClueNum", }));
+						}
+					}
+					break;
+
+				case "toggleCard": {
+					console.log('Case toggleCard reached');
+					let sop: Operative = this.game.getPlayerById(message.id) as Operative;
+					if(re.isCardSelectable(this.game.board.cards, message.cardIndex)
+						&& re.isPlayerTurn(this.game.currTeam, this.game.turn, sop)
+						&& !re.isPlayerSpy(sop)) {
+						let previousSelection = this.game.board.cards.findIndex((card: Card) => {
+							return card.votes.indexOf(sop.name) !== -1;
+						});
+
+						if(previousSelection !== -1) {
+							console.log('first');
+							this.game.toggleCard(sop, previousSelection);
+						}
+
+						if (Number(previousSelection) !== Number(message.cardIndex)) {
+							console.log('second');
+							this.game.toggleCard(sop, message.cardIndex);
+						}
+					}
+
+					let canGuess= re.canSubmitGuess(this.game.findOperatives(), this.game.currTeam);
+					if(canGuess
+						&& !re.isPlayerSpy(sop)
+						&& re.isPlayerTurn(this.game.currTeam, this.game.turn, sop)) {
+						this.game.guessAllowed();
+					}
+
+					break;
+				}
+
+				case "submitGuess":
+					console.log('Case submitGuess reached');
+					let sop: Operative = this.game.getPlayerById(message.id) as Operative;
+					let currSelection = this.game.board.cards.findIndex((card: Card) => {
+						return card.votes.indexOf(sop.name) !== -1;
+					});
+
+					this.game.checkGuess(currSelection as number);
+
+					this.game.findOperatives().filter(op => op.team === sop.team).forEach(
+						innerOp => this.game.toggleCard(innerOp, currSelection)
+					)
+					break;
+
+				case "endGame":
+					console.log('Case endTurn reached');
+					break;
+
+				case "sendMessage":
+					console.log('Case sendMessage reached');
+
+					const player = this.game.getPlayerById(message.id);
+					if(!re.isPlayerSpy(player)) {
+						Broadcaster.sendMessage(this.game.players, message.text, player)
+					}
+					break;
+
+				case "endTurn":
+					console.log('Case endTurn reached');
+
+					let sp: Player = this.game.getPlayerById(message.id) as Player;
+					if(re.isPlayerTurn(this.game.currTeam, this.game.turn, sp)) {
+						this.game.switchActiveTeam();
+					}
+
+					break;
+				default:
+					console.log(`Whoops don't know what ${message} is`);
+			}
+		}
+	}
+}

--- a/src/Manager.ts
+++ b/src/Manager.ts
@@ -14,6 +14,19 @@ import { Team, PlayerLocation } from './constants/Constants';
 import ws = require('ws');
 import { shuffle } from 'lodash'
 
+/**
+ * Manages lobbies, active games and unallocated players. Recieves messages
+ * from WebSocketServer and routes them on to respective Lobbies or Games, or
+ * handles them directly depending on the message.
+ * 
+ * Also keeps track of all players in the system, triggering removal from
+ * respective games, lobbies or unallocated players on a socket close.
+ * 
+ * Uses Game Ids (GIDs) to keep track of current lobbies and games. Players must
+ * provide the GID matching their Player Id (PID) to take action in a game or
+ * lobby. Currently GIDs are drawn from the wordlist, this is a temporary
+ * measure that will be changed in the future.
+ */
 export class Manager {
 	playerStates: Map<ws, PlayerState>;
 	loners: Map<string, Player>;

--- a/src/Operative.ts
+++ b/src/Operative.ts
@@ -1,5 +1,6 @@
 import { Card } from './Card';
 import { Agent } from './Agent';
+import { Loiterer } from './Loiterer';
 import { Team, Turn } from './constants/Constants';
 
 import ws = require('ws')
@@ -10,6 +11,10 @@ export class Operative extends Agent {
 
   constructor(id: string, name: string, socket: ws, team: Team) {
     super(id, name, socket, team, Turn.op);
+  }
+
+  static loitererToOperative(loiterer: Loiterer): Operative {
+    return new Operative(loiterer.id, loiterer.name, loiterer.socket, loiterer.team);
   }
   
   deselectCard() { this.selected = undefined; }

--- a/src/Operative.ts
+++ b/src/Operative.ts
@@ -5,7 +5,6 @@ import { Team, Turn } from './constants/Constants';
 
 import ws = require('ws')
 
-
 export class Operative extends Agent {
   private selected?: Card;
 

--- a/src/PlayerState.ts
+++ b/src/PlayerState.ts
@@ -1,0 +1,27 @@
+import { PlayerLocation } from './constants/Constants'
+
+export class PlayerState {
+	private gid: string;
+	private loc: PlayerLocation;
+
+	constructor() {
+		this.loc = PlayerLocation.loner;
+	}
+
+	getGid() { return this.gid; }
+
+	placeInLobby(gid: string) {
+		if(this.loc !== PlayerLocation.loner)
+			throw new Error("Player must be loner to place in lobby");
+		
+		this.loc = PlayerLocation.lobby;
+		this.gid = gid;
+	}
+
+	placeInGame() {
+		if(this.loc !== PlayerLocation.lobby)
+		throw new Error("Player must be in lobby to place in game");
+	
+		this.loc = PlayerLocation.game;
+	}
+}

--- a/src/PlayerState.ts
+++ b/src/PlayerState.ts
@@ -11,7 +11,12 @@ export class PlayerState {
 	}
 
 	getPid(): string { return this.pid; }
-	getGid(): string | undefined { return this.gid; }
+	getGid(): string {
+		if(!this.gid)
+			throw new Error('Attempted to access gid of player not yet in lobby or game');
+		
+		return this.gid;
+	}
 	getLoc(): PlayerLocation { return this.loc; }
 
 	placeInLobby(gid: string) {
@@ -24,7 +29,7 @@ export class PlayerState {
 
 	placeInGame() {
 		if(this.loc !== PlayerLocation.lobby)
-		throw new Error("Player must be in lobby to place in game");
+			throw new Error("Player must be in lobby to place in game");
 	
 		this.loc = PlayerLocation.game;
 	}

--- a/src/PlayerState.ts
+++ b/src/PlayerState.ts
@@ -1,14 +1,18 @@
 import { PlayerLocation } from './constants/Constants'
 
 export class PlayerState {
-	private gid: string;
+	private gid: string | undefined;
+	private pid: string;
 	private loc: PlayerLocation;
 
-	constructor() {
+	constructor(pid: string) {
+		this.pid = pid;
 		this.loc = PlayerLocation.loner;
 	}
 
-	getGid() { return this.gid; }
+	getPid(): string { return this.pid; }
+	getGid(): string | undefined { return this.gid; }
+	getLoc(): PlayerLocation { return this.loc; }
 
 	placeInLobby(gid: string) {
 		if(this.loc !== PlayerLocation.loner)

--- a/src/Receiver.ts
+++ b/src/Receiver.ts
@@ -1,151 +1,26 @@
 import ws = require('ws')
-import url = require('url')
-
-import { Card } from './Card'
-import { Game } from './Game'
-import { Agent } from './Agent'
-import { Operative } from './Operative'
-import { Broadcaster } from './Broadcaster';
-import { RuleEnforcer as re } from './RuleEnforcer';
-import { GameUtility as gu } from './GameUtility'
+import { Manager } from './Manager'
 
 export class Receiver {
 	wss: ws.Server;
-	game: Game;
+	manager: Manager;
 
 	// make game instance of Game class
-	constructor(socketServer: ws.Server, game: Game) {
+	constructor(socketServer: ws.Server) {
 		this.wss = socketServer;
-		this.game = game;
-
 		this.setupSocketServer();
+		this.manager = new Manager();
 	}
 
 	setupSocketServer() {
-		this.wss.on('connection', (socket, req) => {
+		this.wss.on('connection', (socket: ws, req) => {
 			socket.on('message', (message) => {
-				this.handleMessage(JSON.parse(message.toString()), socket);
+				this.manager.handleMessage(JSON.parse(message.toString()), socket);
 			});
 
 			socket.on('close', (req) => {
-				this.game.removePerson(socket);
-				console.log('Closed connection');
+				this.manager.handleClose(socket);
 			});
 		});
-	}
-
-	handleMessage(message: any, socket: ws) {
-		console.log(message)
-
-		if(message.hasOwnProperty('action')) {
-			let action: string = message.action;
-
-			switch(action) {
-				case "setName":
-					console.log('Case setName reached');
-					if (re.isValidName(message.name)) {
-						this.game.registerLoiterer(message.name, socket);
-					}
-					break;
-
-				case "switchTeam":
-					this.game.switchLoitererTeam(message.id);
-					console.log('Case switchTeam reached');
-					break;
-
-				case "startGame":
-					console.log('Case startGame reached');
-					if(re.canStartGame(gu.getSloitererTeams(this.game.loiterers))) {
-						this.game.startGame();
-					};
-					break;
-
-				case "sendClue":
-					console.log('Case sendClue reached');
-					if(re.isLegalClue(message.clue, this.game.board.cards)
-					&& re.isPlayerTurn(this.game.currTeam, this.game.turn, this.game.getPlayerById(message.id))) {
-						this.game.initializeClue(message.clue);
-					} else {
-						if(!re.isValidWord(message.clue.word)) {
-							socket.send(JSON.stringify({ action: "invalidClueWord", reason: "notWord"}));
-						} else if(re.isWordOnBoard(message.clue.word, this.game.board.cards)) {
-							socket.send(JSON.stringify({ action: "invalidClueWord", reason: "wordOnBoard"}));							
-						} else if(!re.isValidNumGuesses(message.clue.num)) {
-							socket.send(JSON.stringify({ action: "invalidClueNum", }));
-						}
-					}
-					break;
-
-				case "toggleCard": {
-					console.log('Case toggleCard reached');
-					let sop: Operative = this.game.getPlayerById(message.id) as Operative;
-					if(re.isCardSelectable(this.game.board.cards, message.cardIndex)
-						&& re.isPlayerTurn(this.game.currTeam, this.game.turn, sop)
-						&& !re.isPlayerSpy(sop)) {
-						let previousSelection = this.game.board.cards.findIndex((card: Card) => {
-							return card.votes.indexOf(sop.name) !== -1;
-						});
-
-						if(previousSelection !== -1) {
-							console.log('first');
-							this.game.toggleCard(sop, previousSelection);
-						}
-
-						if (Number(previousSelection) !== Number(message.cardIndex)) {
-							console.log('second');
-							this.game.toggleCard(sop, message.cardIndex);
-						}
-					}
-
-					let canGuess= re.canSubmitGuess(this.game.findOperatives(), this.game.currTeam);
-					if(canGuess
-						&& !re.isPlayerSpy(sop)
-						&& re.isPlayerTurn(this.game.currTeam, this.game.turn, sop)) {
-						this.game.guessAllowed();
-					}
-
-					break;
-				}
-
-				case "submitGuess":
-					console.log('Case submitGuess reached');
-					let sop: Operative = this.game.getPlayerById(message.id) as Operative;
-					let currSelection = this.game.board.cards.findIndex((card: Card) => {
-						return card.votes.indexOf(sop.name) !== -1;
-					});
-
-					this.game.checkGuess(currSelection as number);
-
-					this.game.findOperatives().filter(op => op.team === sop.team).forEach(
-						innerOp => this.game.toggleCard(innerOp, currSelection)
-					)
-					break;
-
-				case "endGame":
-					console.log('Case endTurn reached');
-					break;
-
-				case "sendMessage":
-					console.log('Case sendMessage reached');
-
-					const player = this.game.getPlayerById(message.id);
-					if(!re.isPlayerSpy(player)) {
-						Broadcaster.sendMessage(this.game.players, message.text, player)
-					}
-					break;
-
-				case "endTurn":
-					console.log('Case endTurn reached');
-
-					let sp: Agent = this.game.getPlayerById(message.id) as Agent;
-					if(re.isPlayerTurn(this.game.currTeam, this.game.turn, sp)) {
-						this.game.switchActiveTeam();
-					}
-
-					break;
-				default:
-					console.log(`Whoops don't know what ${message} is`);
-			}
-		}
 	}
 }

--- a/src/RuleEnforcer.ts
+++ b/src/RuleEnforcer.ts
@@ -1,22 +1,20 @@
-var checker = require('check-word');
-var words = checker('en');
-
-import { Card } from './Card'
-import { Clue } from './Clue'
-import { Teams } from './Teams'
-import { Agent } from './Agent'
+import { Card } from './Card';
+import { Clue } from './Clue';
+import { Teams } from './Teams';
+import { Agent } from './Agent';
+import { Loiterer } from './Loiterer';
 import { Operative } from './Operative';
 import { Spymaster } from './Spymaster';
-import { Loiterer } from './Loiterer';
+import { GameUtility as gu } from './GameUtility';
 import { Team, Turn } from './constants/Constants';
-import { GameUtility as gu } from './GameUtility'
 
+let words = require('check-word')('en');
 
 export module RuleEnforcer {
   export function isValidName(name: string) { return /^[a-z_ ]+$/i.test(name); }
   
   export function isValidNumGuesses(guesses: number) {
-    return guesses >= 0 && guesses <= 9;
+    return 0 <= guesses && guesses <= 9;
   }
 
   export function isValidWord(word: string) {
@@ -31,12 +29,12 @@ export module RuleEnforcer {
     return isValidWord(clue.word) && isValidNumGuesses(clue.num) && !isWordOnBoard(clue.word, cards);
   }
 
-  export function isAgentTurn(currTeam: Team, currTurn: Turn, player: Agent): boolean {
-    return currTeam === player.team && currTurn === player.role;
+  export function isAgentTurn(currTeam: Team, currTurn: Turn, agent: Agent): boolean {
+    return currTeam === agent.team && currTurn === agent.role;
   }
 
-  export function isAgentSpy(player: Agent): boolean {
-    return player.role === Turn.spy;
+  export function isAgentSpy(agent: Agent): boolean {
+    return agent.role === Turn.spy;
   }
 
   export function isCardSelectable(cards: Card[], cardIndex: number): boolean {

--- a/src/RuleEnforcer.ts
+++ b/src/RuleEnforcer.ts
@@ -31,7 +31,7 @@ export module RuleEnforcer {
     return isValidWord(clue.word) && isValidNumGuesses(clue.num) && !isWordOnBoard(clue.word, cards);
   }
 
-  export function isPlayerTurn(currTeam: Team, currTurn: Turn, player: Agent): boolean {
+  export function isAgentTurn(currTeam: Team, currTurn: Turn, player: Agent): boolean {
     return currTeam === player.team && currTurn === player.role;
   }
 

--- a/src/RuleEnforcer.ts
+++ b/src/RuleEnforcer.ts
@@ -35,7 +35,7 @@ export module RuleEnforcer {
     return currTeam === player.team && currTurn === player.role;
   }
 
-  export function isPlayerSpy(player: Agent): boolean {
+  export function isAgentSpy(player: Agent): boolean {
     return player.role === Turn.spy;
   }
 

--- a/src/RuleEnforcer.ts
+++ b/src/RuleEnforcer.ts
@@ -3,7 +3,7 @@ var words = checker('en');
 
 import { Card } from './Card'
 import { Clue } from './Clue'
-import { SLoitererTeams } from './Teams'
+import { Teams } from './Teams'
 import { Agent } from './Agent'
 import { Operative } from './Operative';
 import { Spymaster } from './Spymaster';
@@ -43,7 +43,7 @@ export module RuleEnforcer {
     return !cards[cardIndex].revealed;
   }
 
-  export function canStartGame(teams: SLoitererTeams): boolean {
+  export function canStartGame(teams: Teams<Loiterer>): boolean {
     return teams.red.length >= 2 && teams.blue.length >= 2;
   }
 

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -22,6 +22,6 @@ app.use(express.static('static'));
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
-let receiver = new Receiver(wss, new Game());
+let receiver = new Receiver(wss);
 
 export default server;

--- a/src/Spymaster.ts
+++ b/src/Spymaster.ts
@@ -1,4 +1,5 @@
 import { Agent } from './Agent';
+import { Loiterer } from './Loiterer';
 import { Team, Turn } from './constants/Constants';
 
 import ws = require('ws');
@@ -6,5 +7,9 @@ import ws = require('ws');
 export class Spymaster extends Agent {
   constructor(id: string, name: string, socket: ws, team: Team) {
     super(id, name, socket, team, Turn.spy);
+  }
+
+  static loitererToSpymaster(loiterer: Loiterer): Spymaster {
+    return new Spymaster(loiterer.id, loiterer.name, loiterer.socket, loiterer.team);
   }
 }

--- a/src/TeamPlayer.ts
+++ b/src/TeamPlayer.ts
@@ -1,0 +1,15 @@
+import { Player } from "./Player";
+import { Team } from "./constants/Constants";
+
+import ws = require('ws')
+
+export abstract class TeamPlayer extends Player {
+	team: Team;
+	
+	constructor(id: string, name: string, socket: ws, team: Team) {
+    super(id, name, socket);
+    this.team = team;
+	}
+	
+	toJSON() { return { id: this.id, name: this.name, team: this.team }; }
+}

--- a/src/Teams.ts
+++ b/src/Teams.ts
@@ -1,21 +1,10 @@
-import { Agent } from './Agent'
-import { Loiterer } from './Loiterer'
+import { TeamPlayer } from './TeamPlayer';
 
-export class SLoitererTeams {
-  readonly red: Loiterer[];
-  readonly blue: Loiterer[];
+export class Teams<T extends TeamPlayer> {
+  readonly red: T[];
+  readonly blue: T[];
 
-  constructor(red: Loiterer[], blue: Loiterer[]) {
-		this.red = red;
-		this.blue = blue;
-  }
-}
-
-export class SPlayerTeams {
-  readonly red: Agent[];
-  readonly blue: Agent[];
-
-  constructor(red: Agent[], blue: Agent[]) {
+  constructor(red: T[], blue: T[]) {
 		this.red = red;
 		this.blue = blue;
   }

--- a/src/constants/Constants.ts
+++ b/src/constants/Constants.ts
@@ -15,3 +15,9 @@ export enum Turn {
   spy = 0,
   op = 1,
 }
+
+export enum PlayerLocation {
+  loner = 0,
+  lobby = 1,
+  game = 2
+}

--- a/test/game_utility.test.ts
+++ b/test/game_utility.test.ts
@@ -10,7 +10,7 @@ import 'mocha';
 import { expect } from 'chai';
 import WebSocket = require('ws')
 import { mock, instance, when } from 'ts-mockito';
-import { SPlayerTeams } from '../src/Teams';
+import { Teams } from '../src/Teams';
 
 describe("Filename: game_utility.test.ts:\n\nGame Utility", () => {
 	let mock_ws: WebSocket;
@@ -38,28 +38,28 @@ describe("Filename: game_utility.test.ts:\n\nGame Utility", () => {
 	});
 
   it("should correctly split loiterers on team", () => {
-		let teams = gu.getSloitererTeams(loiterers);
+		let teams = gu.getTeams(loiterers);
 
 		expect(teams.red.length).to.equal(2);
 		expect(teams.blue.length).to.equal(3);
 	});
 	
   it("should correctly split players on team", () => {
-		let teams = gu.getPlayerTeams(agents);
+		let teams = gu.getTeams(agents);
 
 		expect(teams.red.length).to.equal(3);
 		expect(teams.blue.length).to.equal(2);
 	});
 	
 	it("should get correct number of names from loiterers", () => {
-		let team_names = gu.getSloitererRoster(gu.getSloitererTeams(loiterers));
+		let team_names = gu.getRoster(gu.getTeams(loiterers));
  
 		expect(team_names[Team.red].length).to.equal(2);
 		expect(team_names[Team.blue].length).to.equal(3);
 	});
 	
 	it("should get correct number of names from players", () => {
-		let team_names = gu.getPlayerRoster(gu.getPlayerTeams(agents));
+		let team_names = gu.getRoster(gu.getTeams(agents));
 
 		expect(team_names[Team.red].length).to.equal(3);
 		expect(team_names[Team.blue].length).to.equal(2);

--- a/test/rule_enforcer.test.ts
+++ b/test/rule_enforcer.test.ts
@@ -91,17 +91,17 @@ describe("Filename: rules_enforcer.test.ts:\n\nRules Enforcer", () => {
 	it("should correctly determine if it is player turn", () => {
 		let red = new Operative("test", "1", mock_ws_instance, Team.red);
 
-		expect(re.isPlayerTurn(Team.red, Turn.op, red)).to.be.true;
-		expect(re.isPlayerTurn(Team.red, Turn.spy, red)).to.be.false;
-		expect(re.isPlayerTurn(Team.blue, Turn.op, red)).to.be.false;
-		expect(re.isPlayerTurn(Team.blue, Turn.spy, red)).to.be.false;
+		expect(re.isAgentTurn(Team.red, Turn.op, red)).to.be.true;
+		expect(re.isAgentTurn(Team.red, Turn.spy, red)).to.be.false;
+		expect(re.isAgentTurn(Team.blue, Turn.op, red)).to.be.false;
+		expect(re.isAgentTurn(Team.blue, Turn.spy, red)).to.be.false;
 		
 		let blue = new Spymaster("test", "2", mock_ws_instance, Team.blue);
 
-		expect(re.isPlayerTurn(Team.red, Turn.op, blue)).to.be.false;
-		expect(re.isPlayerTurn(Team.red, Turn.spy, blue)).to.be.false;
-		expect(re.isPlayerTurn(Team.blue, Turn.op, blue)).to.be.false;
-		expect(re.isPlayerTurn(Team.blue, Turn.spy, blue)).to.be.true;
+		expect(re.isAgentTurn(Team.red, Turn.op, blue)).to.be.false;
+		expect(re.isAgentTurn(Team.red, Turn.spy, blue)).to.be.false;
+		expect(re.isAgentTurn(Team.blue, Turn.op, blue)).to.be.false;
+		expect(re.isAgentTurn(Team.blue, Turn.spy, blue)).to.be.true;
 	});
 
 	it("should correctly determine if a player is a spy", () => {

--- a/test/rule_enforcer.test.ts
+++ b/test/rule_enforcer.test.ts
@@ -108,8 +108,8 @@ describe("Filename: rules_enforcer.test.ts:\n\nRules Enforcer", () => {
 		let red = new Operative("test", "1", mock_ws_instance, Team.red);
 		let blue = new Spymaster("test", "2", mock_ws_instance, Team.blue);
 
-		expect(re.isPlayerSpy(red)).to.be.false;
-		expect(re.isPlayerSpy(blue)).to.be.true;
+		expect(re.isAgentSpy(red)).to.be.false;
+		expect(re.isAgentSpy(blue)).to.be.true;
 	});
 
 	it("should correctly determine if a card is selectable", () => {

--- a/test/rule_enforcer.test.ts
+++ b/test/rule_enforcer.test.ts
@@ -138,11 +138,11 @@ describe("Filename: rules_enforcer.test.ts:\n\nRules Enforcer", () => {
 		let cant_start_two = [red_l_one, red_l_two, blue_l_one];
 		let cant_start_three = [red_l_one, blue_l_one, blue_l_two, blue_l_three];
 
-		expect(re.canStartGame(gu.getSloitererTeams(can_start_one))).to.be.true;
-		expect(re.canStartGame(gu.getSloitererTeams(can_start_two))).to.be.true;
-		expect(re.canStartGame(gu.getSloitererTeams(cant_start_one))).to.be.false;
-		expect(re.canStartGame(gu.getSloitererTeams(cant_start_two))).to.be.false;
-		expect(re.canStartGame(gu.getSloitererTeams(cant_start_three))).to.be.false;
+		expect(re.canStartGame(gu.getTeams(can_start_one))).to.be.true;
+		expect(re.canStartGame(gu.getTeams(can_start_two))).to.be.true;
+		expect(re.canStartGame(gu.getTeams(cant_start_one))).to.be.false;
+		expect(re.canStartGame(gu.getTeams(cant_start_two))).to.be.false;
+		expect(re.canStartGame(gu.getTeams(cant_start_three))).to.be.false;
 	});
 
 	it("should correctly determine if a guess can be submitted", () => {		


### PR DESCRIPTION
Adds Manager class which holds players not in lobbies, lobbies that have not yet started a game and active games. These are held as three maps, PID -> free-floating players (those not yet in a lobby), GID -> lobbies not yet in a game, and GID -> active games. When a request comes in the message will have neither PID or GID, just PID, or both PID and GID. Based on the user's ids actions are then routed to the appropriate lobby or game.

Additionally all players and their current state are kept in a map of socket -> PlayerState so that we can remove players as they close connections and delete empty lobbies and games.