### PR TITLE
Updated Procfile to ensure Heroku can run the server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-  web: npm run ts-node game/index.ts
+  web: npm run ts-node src/index.ts


### PR DESCRIPTION
When Heroku runs, it uses the `Procfile` to load processes. The Procfile specified an outdated file, so Heroku gave this error:

```
Error: Cannot find module '/app/game/index.ts' 
```

This corrects that issue by fixing the location of the `index.ts` file based on the previous refactoring work.